### PR TITLE
try try see

### DIFF
--- a/mochi/sqlx-data.json
+++ b/mochi/sqlx-data.json
@@ -1,3 +1,24 @@
 {
-  "db": "PostgreSQL"
+  "db": "PostgreSQL",
+  "5b391d212db30249e2139e024bd6c904ab54d0f96f44b9c5d7155697a7e4e62b": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Varchar",
+          "Text"
+        ]
+      }
+    },
+    "query": "INSERT INTO\n  card (\"name\", description)\nVALUES\n  ($1, $2)\nRETURNING\n  id\n"
+  }
 }

--- a/mochi/src/service/persist/card.rs
+++ b/mochi/src/service/persist/card.rs
@@ -1,25 +1,36 @@
-// use crate::{
-//     domain::model,
-//     service::persist::error::Result,
-// };
-// use async_trait::async_trait;
-// use uuid::Uuid;
+use async_trait::async_trait;
+use snafu::ResultExt;
+use uuid::Uuid;
 
-// #[async_trait]
-// pub trait CardPersistService: Send + Sync {
-//     async fn create(&self, card: &model::CreateCardRequest) -> Result<Uuid>;
+use crate::{
+    domain::model,
+    service::persist::{error, error::Result, DefaultPersistService},
+};
 
-//     async fn get_all(&self) -> Result<Vec<model::Card>>;
+#[async_trait]
+pub trait CardPersistService: Send + Sync {
+    async fn create(&self, card: &model::CreateCardRequest) -> Result<Uuid>;
 
-//     async fn get_by_id(&self) -> Result<Option<model::Card>>;
+    // async fn get_all(&self) -> Result<Vec<model::Card>>;
 
-//     async fn update_by_id(&self) -> Result<Option<model::Card>>;
+    // async fn get_by_id(&self) -> Result<Option<model::Card>>;
 
-//     async fn delete_by_id(&self) -> Result<Option<Uuid>>;
-// }
+    // async fn update_by_id(&self) -> Result<Option<model::Card>>;
 
-// #[async_trait]
-// impl CardPersistService for DefaultPersistService {
-//   async fn create(&self, model::CreateCardRequest {name, description}:
-// &model::CreateCardRequest) -> Result<Uuid>{     sqlx::query_file!("sql/card/
-// insert.sql", name, description)   }
+    // async fn delete_by_id(&self) -> Result<Option<Uuid>>;
+}
+
+#[async_trait]
+impl CardPersistService for DefaultPersistService {
+    async fn create(
+        &self,
+        model::CreateCardRequest { name, description }: &model::CreateCardRequest,
+    ) -> Result<Uuid> {
+        let record = sqlx::query_file!("sql/card/insert.sql", name, description)
+            .fetch_one(&self.postgres)
+            .await
+            .context(error::CreateCardSnafu)?;
+
+        Ok(record.id)
+    }
+}

--- a/mochi/src/service/persist/error.rs
+++ b/mochi/src/service/persist/error.rs
@@ -1,7 +1,35 @@
-use snafu::Snafu;
+use std::fmt;
 
-// pub type Result<T> = std::result::Result<T, Error>;
+use snafu::{Backtrace, Snafu};
+
+pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
-pub enum Error {}
+pub enum Error {
+    #[snafu(display(
+        "Error occurs while creating `Unit` in PostgreSQL{}",
+        fmt_backtrace_with_source(backtrace, source)
+    ))]
+    CreateCard { source: sqlx::Error, backtrace: Backtrace },
+}
+
+#[inline]
+#[must_use]
+pub fn fmt_backtrace_with_source(backtrace: &Backtrace, source: impl fmt::Display) -> String {
+    format!("{}{}", fmt_backtrace(backtrace), fmt_source(source))
+}
+
+#[inline]
+#[must_use]
+pub fn fmt_backtrace(backtrace: &Backtrace) -> String {
+    if cfg!(feature = "backtrace") {
+        format!("\n{}", backtrace)
+    } else {
+        String::new()
+    }
+}
+
+#[inline]
+#[must_use]
+pub fn fmt_source(source: impl fmt::Display) -> String { format!("\nCaused by: {}", source) }

--- a/mochi/src/service/persist/mod.rs
+++ b/mochi/src/service/persist/mod.rs
@@ -1,13 +1,13 @@
+use sqlx::{Pool, Postgres};
+
 mod card;
 pub mod error;
 
-// #[derive(Clone)]
-// pub struct DefaultPersistService {
-//     postgres: Pool<Postgres>,
-// }
+#[derive(Clone)]
+pub struct DefaultPersistService {
+    postgres: Pool<Postgres>,
+}
 
-// impl DefaultPersistService {
-//     pub const fn new(postgres: Pool<Postgres>) -> Self {
-//         Self { postgres }
-//     }
-// }
+impl DefaultPersistService {
+    pub const fn new(postgres: Pool<Postgres>) -> Self { Self { postgres } }
+}


### PR DESCRIPTION
- feat: init tokio Runtime (run command) and error handling
- feat: init AxumWebServer in run command
- feat: init CARD web API endpoint
- feat: init card entity & card model
- feat: card Mock API
- feat: card API request params and path name
- chore: add sqlx to dev-shell.nix
- feat: init postgres connection pool
- feat: init sql migration & query files
- feat: card persist service
- feat: try try see
